### PR TITLE
Add content to Team page

### DIFF
--- a/frontend/src/components/commons/TeamCard.vue
+++ b/frontend/src/components/commons/TeamCard.vue
@@ -10,15 +10,20 @@
         <v-col class="mx-2" cols="3" id="avatar-col">
           <v-avatar size="90">
             <img
-              :src="avatarUrl"
-              :alt="name"
+              :src="info.avatar_url"
+              :alt="info.login"
               @click="redirectToUserPage()"
-              :title="name"
+              :title="info.login"
             />
           </v-avatar>
         </v-col>
         <v-col class="mx-2" id="info-col">
-          <v-card-title class="font-weight-bold">{{ name }} </v-card-title>
+          <v-card-title class="font-weight-bold"
+            >{{ info.login }}
+          </v-card-title>
+          <v-card-subtitle class="text-left orange--text text--darken-3"
+            >Contributions: {{ info.contributions }}</v-card-subtitle
+          >
           <v-card-text class="text-left text-body-1"
             >{{ description }}
           </v-card-text>
@@ -33,14 +38,14 @@
     >
       <v-avatar size="90">
         <img
-          :src="avatarUrl"
-          :alt="name"
+          :src="info.avatar_url"
+          :alt="info.login"
           @click="redirectToUserPage()"
-          :title="name"
+          :title="info.login"
         />
       </v-avatar>
       <v-card-title class="font-weight-bold justify-center"
-        >{{ name }}
+        >{{ info.login }}
       </v-card-title>
       <v-card-text class="text-body-1">{{ description }} </v-card-text>
     </v-card>
@@ -49,7 +54,7 @@
 
 <script>
 export default {
-  props: ["name", "avatarUrl", "description", "url"],
+  props: ["description", "info"],
   data() {
     return {
       screenWidth: 0,
@@ -58,7 +63,7 @@ export default {
   },
   methods: {
     redirectToUserPage() {
-      window.open(this.url);
+      window.open(this.info.html_url);
     },
     handleScreenResize() {
       this.screenWidth = window.innerWidth;
@@ -87,12 +92,4 @@ export default {
 img:hover {
   cursor: pointer;
 }
-
-/* #avatar-col {
-  background: lightblue;
-} */
-
-/* #info-col {
-  background: pink;
-} */
 </style>

--- a/frontend/src/components/commons/TeamCard.vue
+++ b/frontend/src/components/commons/TeamCard.vue
@@ -21,9 +21,9 @@
           <v-card-title class="font-weight-bold"
             >{{ info.login }}
           </v-card-title>
-          <v-card-subtitle class="text-left orange--text text--darken-3"
-            >Contributions: {{ info.contributions }}</v-card-subtitle
-          >
+          <v-card-subtitle class="text-left orange--text text--darken-3">
+            Contributions: {{ info.contributions }}
+          </v-card-subtitle>
           <v-card-text class="text-left text-body-1"
             >{{ description }}
           </v-card-text>
@@ -47,6 +47,9 @@
       <v-card-title class="font-weight-bold justify-center"
         >{{ info.login }}
       </v-card-title>
+      <v-card-subtitle class="orange--text text--darken-3">
+        Contributions: {{ info.contributions }}
+      </v-card-subtitle>
       <v-card-text class="text-body-1">{{ description }} </v-card-text>
     </v-card>
   </v-container>

--- a/frontend/src/components/commons/TeamCard.vue
+++ b/frontend/src/components/commons/TeamCard.vue
@@ -1,0 +1,98 @@
+<template>
+  <v-container>
+    <v-card
+      v-show="!this.isPortrait"
+      rounded="xl"
+      class="py-8 ml-8"
+      width="80%"
+    >
+      <v-row class="align-center">
+        <v-col class="mx-2" cols="3" id="avatar-col">
+          <v-avatar size="90">
+            <img
+              :src="avatarUrl"
+              :alt="name"
+              @click="redirectToUserPage()"
+              :title="name"
+            />
+          </v-avatar>
+        </v-col>
+        <v-col class="mx-2" id="info-col">
+          <v-card-title class="font-weight-bold">{{ name }} </v-card-title>
+          <v-card-text class="text-left text-body-1"
+            >{{ description }}
+          </v-card-text>
+        </v-col>
+      </v-row>
+    </v-card>
+    <v-card
+      v-show="this.isPortrait"
+      rounded="xl"
+      class="py-8 my-4 ml-8"
+      width="80%"
+    >
+      <v-avatar size="90">
+        <img
+          :src="avatarUrl"
+          :alt="name"
+          @click="redirectToUserPage()"
+          :title="name"
+        />
+      </v-avatar>
+      <v-card-title class="font-weight-bold justify-center"
+        >{{ name }}
+      </v-card-title>
+      <v-card-text class="text-body-1">{{ description }} </v-card-text>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+export default {
+  props: ["name", "avatarUrl", "description", "url"],
+  data() {
+    return {
+      screenWidth: 0,
+      isPortrait: false,
+    };
+  },
+  methods: {
+    redirectToUserPage() {
+      window.open(this.url);
+    },
+    handleScreenResize() {
+      this.screenWidth = window.innerWidth;
+      var widthToHeightRatio = window.innerWidth / window.innerHeight;
+      if (widthToHeightRatio < 1) {
+        this.isPortrait = true;
+      } else {
+        this.isPortrait = false;
+      }
+    },
+  },
+  created() {
+    window.addEventListener("resize", this.handleScreenResize);
+  },
+  destroyed() {
+    window.removeEventListener("resize", this.handleScreenResize);
+  },
+  mounted() {
+    this.screenWidth = window.innerWidth;
+    this.handleScreenResize();
+  },
+};
+</script>
+
+<style scoped>
+img:hover {
+  cursor: pointer;
+}
+
+/* #avatar-col {
+  background: lightblue;
+} */
+
+/* #info-col {
+  background: pink;
+} */
+</style>

--- a/frontend/src/httpRequests/GithubRequest.js
+++ b/frontend/src/httpRequests/GithubRequest.js
@@ -3,6 +3,8 @@ import axios from "axios";
 const GITHUB_REPO_BASE_URL = "https://github.com/Linxcathyyy/rateNUS";
 const GITHUB_API_URL =
   "https://api.github.com/repos/Linxcathyyy/rateNUS/commits";
+const GITHUB_API_CONTRIBUTORS_INFO =
+  "https://api.github.com/repos/Linxcathyyy/rateNUS/contributors";
 const GITHUB_CONTRIBUTORS_URL =
   "https://github.com/Linxcathyyy/rateNUS/graphs/contributors";
 
@@ -35,6 +37,10 @@ class GithubRequest {
 
   getContributorsUrl() {
     return GITHUB_CONTRIBUTORS_URL;
+  }
+
+  async getContributorsInfo() {
+    return (await axios.get(GITHUB_API_CONTRIBUTORS_INFO)).data;
   }
 }
 

--- a/frontend/src/views/Team.vue
+++ b/frontend/src/views/Team.vue
@@ -1,12 +1,38 @@
 <template>
   <div>
     <h1 class="my-4 text-left">Team</h1>
-    <v-divider></v-divider>
+    <v-divider class="mb-8"></v-divider>
+    <v-container
+      id="team-cards"
+      v-for="contributor in this.contributors"
+      :key="contributor.id"
+    >
+      <TeamCard
+        :name="contributor.login"
+        :avatarUrl="contributor.avatar_url"
+        :url="contributor.html_url"
+        description="Test Placeholder Description"
+      />
+    </v-container>
   </div>
 </template>
 
 <script>
-export default {};
+import TeamCard from "../components/commons/TeamCard.vue";
+import GithubRequest from "../httpRequests/GithubRequest.js";
+export default {
+  components: {
+    TeamCard,
+  },
+  data() {
+    return {
+      contributors: [],
+    };
+  },
+  async mounted() {
+    this.contributors = await GithubRequest.getContributorsInfo();
+  },
+};
 </script>
 
-<style></style>
+<style scoped></style>

--- a/frontend/src/views/Team.vue
+++ b/frontend/src/views/Team.vue
@@ -8,9 +8,7 @@
       :key="contributor.id"
     >
       <TeamCard
-        :name="contributor.login"
-        :avatarUrl="contributor.avatar_url"
-        :url="contributor.html_url"
+        :info="contributor"
         description="Test Placeholder Description"
       />
     </v-container>

--- a/frontend/src/views/Team.vue
+++ b/frontend/src/views/Team.vue
@@ -9,7 +9,7 @@
     >
       <TeamCard
         :info="contributor"
-        description="Test Placeholder Description"
+        :description="getMemberDescriptionByName(contributor.login)"
       />
     </v-container>
   </div>
@@ -25,10 +25,24 @@ export default {
   data() {
     return {
       contributors: [],
+      descriptions: {
+        // add your descriptions here
+        // Format:
+        // {git id}: "{description}",
+        JeffZincatz: "Test descrption",
+      },
     };
   },
   async mounted() {
     this.contributors = await GithubRequest.getContributorsInfo();
+  },
+  methods: {
+    getMemberDescriptionByName(name) {
+      if (this.descriptions[name] == undefined) {
+        return "This member is lazy and did not provide any description.";
+      }
+      return this.descriptions[name];
+    },
   },
 };
 </script>


### PR DESCRIPTION
- Display team contributor info, including:
  - Github name
  - Github avatar
  - Contribution count
  - Description
- Description can be added later on. (Currently, it can be hardcoded into an object.)

![image](https://user-images.githubusercontent.com/76839641/147852667-e3e3a1e8-6d79-4efc-8eff-90ad92065492.png)

![image](https://user-images.githubusercontent.com/76839641/147852668-d3c01ceb-5f82-4f40-b404-c6338704f100.png)
